### PR TITLE
Tool: revert the PlatformTarget to x86

### DIFF
--- a/Vernacular.Tool/Vernacular.Tool.csproj
+++ b/Vernacular.Tool/Vernacular.Tool.csproj
@@ -35,7 +35,7 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <NoWarn>1685</NoWarn>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Test|AnyCPU'">


### PR DESCRIPTION
The PlatformTarget was changed from x86 to AnyCPU at 909a91. For unknown
reason, this was generating a crash inside of Cecil.